### PR TITLE
Add Kagi.com to user agents list

### DIFF
--- a/src/types/UserAgent.ts
+++ b/src/types/UserAgent.ts
@@ -60,6 +60,8 @@ export type SearchEngines = {
   Istella: "istellabot";
   // jike.com / chinaso.com chinese search engine
   Jike: "JikeSpider";
+  // Kagi.com, premium private search engine
+  Kagi: "Kagibot";
   // lycos.com & hotbot.com international search engine
   Lycos: "Lycos";
   // mail.ru russian search engine


### PR DESCRIPTION
Hello!  Thank you for this helpful library!

I was setting it up this afternoon for a project and realized that when I updated the config to use [Kagi's crawler](https://kagi.com), it threw an error.

Based on their docs at https://kagi.com/bot, `Kagibot` should be the correct identifier, so I added it to the `UserAgent.ts` file 

